### PR TITLE
Additional customization options: integer type and starting index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 *.swo
 *.swp
+types3.toml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 *.swo
 *.swp
 types3.toml
+types4.toml

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,6 +15,20 @@ fn check_simple() {
 }
 
 #[test]
+fn check_simple_custom_type() {
+    use unique_type_id::UniqueTypeId;
+    #[derive(UniqueTypeId)]
+    #[UniqueTypeIdType = "i16"]
+    struct Test1;
+    #[derive(UniqueTypeId)]
+    #[UniqueTypeIdType = "i16"]
+    struct Test2;
+
+    assert_eq!(Test1::id().0, 1i16);
+    assert_eq!(Test2::id().0, 2i16);
+}
+
+#[test]
 fn check_simple_second() {
     use unique_type_id::UniqueTypeId;
     #[derive(UniqueTypeId)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -87,3 +87,22 @@ fn check_simple_empty_file() {
     assert!(unique_ids.contains(&1u64));
     assert_ne!(Test1::id().0, Test2::id().0);
 }
+
+#[test]
+fn check_empty_file_custom_start() {
+    use unique_type_id::UniqueTypeId;
+    #[derive(UniqueTypeId)]
+    #[UniqueTypeIdFile = "types4.toml"]
+    #[UniqueTypeIdStart = 23]
+    struct Test1;
+    #[derive(UniqueTypeId)]
+    #[UniqueTypeIdFile = "types4.toml"]
+    #[UniqueTypeIdStart = 23]
+    struct Test2;
+
+    // One of Test1 or Test2 should get "23", and the other should get "24"
+    let unique_ids = [Test1::id().0, Test2::id().0];
+    assert!(unique_ids.contains(&23u64));
+    assert!(unique_ids.contains(&24u64));
+    assert_ne!(Test1::id().0, Test2::id().0);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -67,6 +67,9 @@ fn check_simple_empty_file() {
     #[UniqueTypeIdFile = "types3.toml"]
     struct Test2;
 
-    assert_eq!(Test1::id().0, 0u64);
-    assert_eq!(Test2::id().0, 1u64);
+    // One of Test1 or Test2 should get "0", and the other should get "1"
+    let unique_ids = [Test1::id().0, Test2::id().0];
+    assert!(unique_ids.contains(&0u64));
+    assert!(unique_ids.contains(&1u64));
+    assert_ne!(Test1::id().0, Test2::id().0);
 }

--- a/unique-type-id-derive/src/lib.rs
+++ b/unique-type-id-derive/src/lib.rs
@@ -12,12 +12,12 @@ use std::collections::BTreeMap;
 use proc_macro::TokenStream;
 use fs2::FileExt;
 
-static TYPES_FILE_NAME: &'static str = "types.toml";
+static DEFAULT_TYPES_FILE_NAME: &'static str = "types.toml";
+static DEFAULT_ID_TYPE: &'static str = "u64";
 
-type Value = u64;
-type PairsMap = BTreeMap<String, Value>;
+type PairsMap = BTreeMap<String, u64>;
 
-#[proc_macro_derive(UniqueTypeId, attributes(UniqueTypeIdFile))]
+#[proc_macro_derive(UniqueTypeId, attributes(UniqueTypeIdFile, UniqueTypeIdType))]
 pub fn unique_type_id(input: TokenStream) -> TokenStream {
     implement_type_id(input, unique_implementor)
 }
@@ -50,14 +50,14 @@ fn file_string_to_tree(file_contents: String) -> PairsMap {
     map
 }
 
-fn pair_from_line(line: &str) -> Option<(String, Value)> {
+fn pair_from_line(line: &str) -> Option<(String, u64)> {
     let mut pair = line.split('=');
     let key = pair.next()?.to_owned();
-    let value = pair.next()?.parse::<Value>().ok()?;
+    let value = pair.next()?.parse::<u64>().ok()?;
     Some((key, value))
 }
 
-fn append_pair_to_file(file_name: &str, record: &str, value: Value) {
+fn append_pair_to_file(file_name: &str, record: &str, value: u64) {
     use std::io::Write;
     use std::fs::OpenOptions;
 
@@ -74,7 +74,7 @@ fn append_pair_to_file(file_name: &str, record: &str, value: Value) {
     f.unlock().expect("Unable to unlock the file");
 }
 
-fn gen_id(file_name: &str, record: &str) -> Value {
+fn gen_id(file_name: &str, record: &str) -> u64 {
     let pairs_map = file_string_to_tree(read_file_into_string(file_name));
     match pairs_map.get(record) {
         Some(record_id) => record_id.to_owned(),
@@ -124,19 +124,38 @@ fn parse_types_file_name(attrs: &[syn::Attribute]) -> String {
             }
         }
     }
-    TYPES_FILE_NAME.to_owned()
+    DEFAULT_TYPES_FILE_NAME.to_owned()
+}
+
+fn parse_id_type(attrs: &[syn::Attribute]) -> String {
+    let name = attrs
+        .iter()
+        .filter(|a| a.value.name() == "UniqueTypeIdType")
+        .next();
+    if let Some(name) = name {
+        if let syn::MetaItem::NameValue(_, ref value) = name.value {
+            match value {
+                &syn::Lit::Str(ref value, _) => return value.to_owned(),
+                _ => {}
+            }
+        }
+    }
+    DEFAULT_ID_TYPE.to_owned()
 }
 
 fn unique_implementor(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let types_file_name = parse_types_file_name(&ast.attrs);
+    let id_type_name = parse_id_type(&ast.attrs);
+    let id_type = syn::parse_type(&id_type_name).unwrap();
     let id = gen_id(&types_file_name, name.as_ref());
 
     quote! {
-        impl #impl_generics unique_type_id::UniqueTypeId for #name #ty_generics #where_clause {
-            fn id() -> unique_type_id::TypeId {
-                unique_type_id::TypeId(#id)
+        impl #impl_generics unique_type_id::UniqueTypeId<#id_type> for #name #ty_generics #where_clause {
+            const TYPE_ID: unique_type_id::TypeId<#id_type> = unique_type_id::TypeId(#id as #id_type);
+            fn id() -> unique_type_id::TypeId<#id_type> {
+              Self::TYPE_ID
             }
         }
     }

--- a/unique-type-id-derive/src/lib.rs
+++ b/unique-type-id-derive/src/lib.rs
@@ -14,10 +14,11 @@ use fs2::FileExt;
 
 static DEFAULT_TYPES_FILE_NAME: &'static str = "types.toml";
 static DEFAULT_ID_TYPE: &'static str = "u64";
+static DEFAULT_ID_START: &'static str = "0";
 
 type PairsMap = BTreeMap<String, u64>;
 
-#[proc_macro_derive(UniqueTypeId, attributes(UniqueTypeIdFile, UniqueTypeIdType))]
+#[proc_macro_derive(UniqueTypeId, attributes(UniqueTypeIdFile, UniqueTypeIdType, UniqueTypeIdStart))]
 pub fn unique_type_id(input: TokenStream) -> TokenStream {
     implement_type_id(input, unique_implementor)
 }
@@ -74,12 +75,12 @@ fn append_pair_to_file(file_name: &str, record: &str, value: u64) {
     f.unlock().expect("Unable to unlock the file");
 }
 
-fn gen_id(file_name: &str, record: &str) -> u64 {
+fn gen_id(file_name: &str, record: &str, start: u64) -> u64 {
     let pairs_map = file_string_to_tree(read_file_into_string(file_name));
     match pairs_map.get(record) {
         Some(record_id) => record_id.to_owned(),
         None => {
-            let mut new_id = 0;
+            let mut new_id = start;
 
             loop {
                 if !pairs_map.values().find(|id| &new_id == *id).is_some() {
@@ -111,46 +112,33 @@ fn implement_type_id(
     gen.parse().unwrap()
 }
 
-fn parse_types_file_name(attrs: &[syn::Attribute]) -> String {
+fn parse_attribute(attrs: &[syn::Attribute], name: &str, default: &str) -> String {
     let name = attrs
         .iter()
-        .filter(|a| a.value.name() == "UniqueTypeIdFile")
+        .filter(|a| a.value.name() == name)
         .next();
     if let Some(name) = name {
-        if let syn::MetaItem::NameValue(_, ref value) = name.value {
+        if let syn::MetaItem::NameValue(ref ident, ref value) = name.value {
             match value {
                 &syn::Lit::Str(ref value, _) => return value.to_owned(),
-                _ => {}
+                &syn::Lit::Int(ref value, _) => return value.to_string(),
+                _ => panic!("Unable to interpret {} value: {:?}", ident, value),
             }
         }
     }
-    DEFAULT_TYPES_FILE_NAME.to_owned()
-}
-
-fn parse_id_type(attrs: &[syn::Attribute]) -> String {
-    let name = attrs
-        .iter()
-        .filter(|a| a.value.name() == "UniqueTypeIdType")
-        .next();
-    if let Some(name) = name {
-        if let syn::MetaItem::NameValue(_, ref value) = name.value {
-            match value {
-                &syn::Lit::Str(ref value, _) => return value.to_owned(),
-                _ => {}
-            }
-        }
-    }
-    DEFAULT_ID_TYPE.to_owned()
+    default.to_owned()
 }
 
 fn unique_implementor(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-    let types_file_name = parse_types_file_name(&ast.attrs);
-    let id_type_name = parse_id_type(&ast.attrs);
+    let types_file_name = parse_attribute(&ast.attrs, "UniqueTypeIdFile", DEFAULT_TYPES_FILE_NAME);
+    let id_type_name = parse_attribute(&ast.attrs, "UniqueTypeIdType", DEFAULT_ID_TYPE);
+    let gen_start: u64 = parse_attribute(&ast.attrs, "UniqueTypeIdStart", DEFAULT_ID_START).parse().unwrap();
     let id_type = syn::parse_type(&id_type_name).unwrap();
-    let id = gen_id(&types_file_name, name.as_ref());
+    let id = gen_id(&types_file_name, name.as_ref(), gen_start);
 
+    // TODO: Use TryFrom instead of `#id as #id_type` to avoid silently destructive casts
     quote! {
         impl #impl_generics unique_type_id::UniqueTypeId<#id_type> for #name #ty_generics #where_clause {
             const TYPE_ID: unique_type_id::TypeId<#id_type> = unique_type_id::TypeId(#id as #id_type);

--- a/unique-type-id/src/lib.rs
+++ b/unique-type-id/src/lib.rs
@@ -26,14 +26,17 @@
 //!    assert_eq!(Test1::id().0, 1u64);
 //!    assert_eq!(Test2::id().0, 2u64);
 //!}
+//! ```
 extern crate quote;
 extern crate syn;
 
 /// A strong type for type id.
-pub struct TypeId(pub u64);
+pub struct TypeId<T>(pub T);
 
 /// A trait for providing a type id number.
-pub trait UniqueTypeId {
+pub trait UniqueTypeId<T> {
+    const TYPE_ID: TypeId<T>;
+
     /// Returns the type id number.
-    fn id() -> TypeId;
+    fn id() -> TypeId<T>;
 }


### PR DESCRIPTION
Added two new configuration attributes:

* UniqueTypeIdType: Specify an integer type other than `u64`. This is a potentially breaking change, since it makes the public API types `TypeId` and `UniqueTypeId` generic.
* UniqueTypeIdStart: Specify a starting index for generated ids other than `0`.
* Added a trait-level `TYPE_ID` const (may address #1)

Additionally, I made a couple small fixes to tests. In particular, in `check_empty_file_custom_start`, there's no guarantee that `Test1` would get allocated a number before `Test2` does, so the test would sometimes give a false negative.