### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,10 +56,6 @@ checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 [[package]]
 name = "unique-type-id"
 version = "1.2.0"
-dependencies = [
- "quote",
- "syn",
-]
 
 [[package]]
 name = "unique-type-id-derive"

--- a/unique-type-id/Cargo.toml
+++ b/unique-type-id/Cargo.toml
@@ -12,5 +12,3 @@ readme = "README.md"
 categories = ["development-tools"]
 
 [dependencies]
-syn = "2"
-quote = "1"

--- a/unique-type-id/src/lib.rs
+++ b/unique-type-id/src/lib.rs
@@ -27,8 +27,7 @@
 //!    assert_eq!(Test2::id().0, 2u64);
 //!}
 //! ```
-extern crate quote;
-extern crate syn;
+#![no_std]
 
 /// A strong type for type id.
 #[repr(transparent)]


### PR DESCRIPTION
I'm writing an ECS for retro consoles.
My first one is the Game Boy Advance.

TypeId is a massive 16 bytes in size. With most of the GBA's bus being 2 bytes wide, that's bad for performance. Let's not talk much about the memory scarcity too. This crate's ability to make unique type IDs from u16 is a perfect solution.

The only hangup is that this crate can't build in the no_std environment of the GBA. This PR fixes that up.