### PR TITLE
Fix procedural macro for lifetime and impl generics

### DIFF
--- a/unique-type-id-derive/src/lib.rs
+++ b/unique-type-id-derive/src/lib.rs
@@ -243,7 +243,7 @@ fn unique_implementor(ast: &syn::DeriveInput) -> TokenStream {
             }
         }
 
-        impl #name #ty_generics #where_clause {
+        impl #impl_generics #name #ty_generics #where_clause {
             const fn unique_type_id() -> unique_type_id::TypeId<#id_type> {
                 Self::TYPE_ID
             }

--- a/unique-type-id-derive/tests/tests.rs
+++ b/unique-type-id-derive/tests/tests.rs
@@ -114,3 +114,13 @@ fn check_empty_file_custom_start() {
     assert!(unique_ids.contains(&24u64));
     assert_ne!(Test1::id().0, Test2::id().0);
 }
+
+#[test]
+fn check_lifetime() {
+    use unique_type_id::UniqueTypeId;
+    #[derive(UniqueTypeId)]
+    struct Test<'a> {
+        d: &'a str
+    }
+    assert!(Test::id().0, 1u64);
+}


### PR DESCRIPTION
Fixes #95.

Disclaimer: I'm unfamiliar with procedural macros. If there are errors, propose fixes please.

This should fix type generics and lifetimes on the secondary impl block.